### PR TITLE
[CosmosDB Restore] Introduce restore with ttl disable in stable

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/_params.py
@@ -397,6 +397,7 @@ def load_arguments(self, _):
         c.argument('assign_identity', nargs='*', help="Assign system or user assigned identities separated by spaces. Use '[system]' to refer system assigned identity.")
         c.argument('default_identity', help="The primary identity to access key vault in CMK related features. e.g. 'FirstPartyIdentity', 'SystemAssignedIdentity' and more.")
         c.argument('public_network_access', options_list=['--public-network-access', '-p'], arg_type=get_enum_type(['ENABLED', 'DISABLED']), help="Sets public network access in server to either Enabled or Disabled.")
+        c.argument('disable_ttl', options_list=['--disable-ttl', '-dt'], arg_type=get_three_state_flag(), help="Enable or disable restoring with ttl disabled.")
 
     # Mongo role definition
     with self.argument_context('cosmosdb mongodb role definition') as c:

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -241,7 +241,8 @@ def _create_database_account(client,
                              arm_location=None,
                              enable_partition_merge=None,
                              enable_burst_capacity=None,
-                             minimal_tls_version=None):
+                             minimal_tls_version=None,
+                             disable_ttl=None):
 
     consistency_policy = None
     if default_consistency_level is not None:
@@ -346,6 +347,9 @@ def _create_database_account(client,
 
         if tables_to_restore is not None:
             restore_parameters.tables_to_restore = tables_to_restore
+
+        if disable_ttl is not None:
+            restore_parameters.restore_with_ttl_disabled = disable_ttl
 
     params = DatabaseAccountCreateUpdateParameters(
         location=arm_location,
@@ -1800,7 +1804,8 @@ def cli_cosmosdb_restore(cmd,
                          databases_to_restore=None,
                          gremlin_databases_to_restore=None,
                          tables_to_restore=None,
-                         public_network_access=None):
+                         public_network_access=None,
+                         disable_ttl=None):
     from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_database_accounts
     restorable_database_accounts_client = cf_restorable_database_accounts(cmd.cli_ctx, [])
     restorable_database_accounts = restorable_database_accounts_client.list()
@@ -1906,7 +1911,8 @@ def cli_cosmosdb_restore(cmd,
                                     gremlin_databases_to_restore=gremlin_databases_to_restore,
                                     tables_to_restore=tables_to_restore,
                                     arm_location=target_restorable_account.location,
-                                    public_network_access=public_network_access)
+                                    public_network_access=public_network_access,
+                                    disable_ttl=disable_ttl)
 
 
 def _convert_to_utc_timestamp(timestamp_string):
@@ -2806,7 +2812,8 @@ def cli_cosmosdb_sql_database_restore(cmd,
                                       resource_group_name,
                                       account_name,
                                       database_name,
-                                      restore_timestamp=None):
+                                      restore_timestamp=None,
+                                      disable_ttl=None):
 
     from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_database_accounts
     restorable_database_accounts_client = cf_restorable_database_accounts(cmd.cli_ctx, [])
@@ -2869,6 +2876,9 @@ def cli_cosmosdb_sql_database_restore(cmd,
         restore_timestamp_in_utc=restore_timestamp
     )
 
+    if disable_ttl is not None:
+        restore_parameters.restore_with_ttl_disabled = disable_ttl
+
     sql_database_resource = SqlDatabaseCreateUpdateParameters(
         resource=SqlDatabaseResource(
             id=database_name,
@@ -2888,7 +2898,8 @@ def cli_cosmosdb_sql_container_restore(cmd,
                                        account_name,
                                        database_name,
                                        container_name,
-                                       restore_timestamp=None):
+                                       restore_timestamp=None,
+                                       disable_ttl=None):
 
     from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_database_accounts
     # """Restores the deleted Azure Cosmos DB SQL container """
@@ -2968,6 +2979,9 @@ def cli_cosmosdb_sql_container_restore(cmd,
         restore_timestamp_in_utc=restore_timestamp
     )
 
+    if disable_ttl is not None:
+        restore_parameters.restore_with_ttl_disabled = disable_ttl
+
     sql_container_resource = SqlContainerResource(
         id=container_name,
         create_mode=create_mode,
@@ -2989,7 +3003,8 @@ def cli_cosmosdb_mongodb_database_restore(cmd,
                                           resource_group_name,
                                           account_name,
                                           database_name,
-                                          restore_timestamp=None):
+                                          restore_timestamp=None,
+                                          disable_ttl=None):
 
     from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_database_accounts
     # """Restores the deleted Azure Cosmos DB MongoDB database"""
@@ -3053,6 +3068,9 @@ def cli_cosmosdb_mongodb_database_restore(cmd,
         restore_timestamp_in_utc=restore_timestamp
     )
 
+    if disable_ttl is not None:
+        restore_parameters.restore_with_ttl_disabled = disable_ttl
+
     mongodb_database_resource = MongoDBDatabaseCreateUpdateParameters(
         resource=MongoDBDatabaseResource(id=database_name,
                                          create_mode=create_mode,
@@ -3071,7 +3089,8 @@ def cli_cosmosdb_mongodb_collection_restore(cmd,
                                             account_name,
                                             database_name,
                                             collection_name,
-                                            restore_timestamp=None):
+                                            restore_timestamp=None,
+                                            disable_ttl=None):
 
     from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_database_accounts
     # """Restores the Azure Cosmos DB MongoDB collection """
@@ -3151,6 +3170,9 @@ def cli_cosmosdb_mongodb_collection_restore(cmd,
         restore_timestamp_in_utc=restore_timestamp
     )
 
+    if disable_ttl is not None:
+        restore_parameters.restore_with_ttl_disabled=disable_ttl
+
     mongodb_collection_resource = MongoDBCollectionResource(id=collection_name,
                                                             create_mode=create_mode,
                                                             restore_parameters=restore_parameters
@@ -3172,7 +3194,8 @@ def cli_cosmosdb_gremlin_database_restore(cmd,
                                           resource_group_name,
                                           account_name,
                                           database_name,
-                                          restore_timestamp=None):
+                                          restore_timestamp=None,
+                                          disable_ttl=None):
 
     from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_database_accounts
     restorable_database_accounts_client = cf_restorable_database_accounts(cmd.cli_ctx, [])
@@ -3235,6 +3258,9 @@ def cli_cosmosdb_gremlin_database_restore(cmd,
         restore_timestamp_in_utc=restore_timestamp
     )
 
+    if disable_ttl is not None:
+        restore_parameters.restore_with_ttl_disabled=disable_ttl
+
     gremlin_database_resource = GremlinDatabaseCreateUpdateParameters(
         resource=SqlDatabaseResource(
             id=database_name,
@@ -3254,7 +3280,8 @@ def cli_cosmosdb_gremlin_graph_restore(cmd,
                                        account_name,
                                        database_name,
                                        graph_name,
-                                       restore_timestamp=None):
+                                       restore_timestamp=None,
+                                       disable_ttl=None):
 
     from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_database_accounts
     # """Restores the deleted Azure Cosmos DB Gremlin graph """
@@ -3334,6 +3361,9 @@ def cli_cosmosdb_gremlin_graph_restore(cmd,
         restore_timestamp_in_utc=restore_timestamp
     )
 
+    if disable_ttl is not None:
+        restore_parameters.restore_with_ttl_disabled=disable_ttl
+
     gremlin_graph_resource = GremlinGraphResource(
         id=graph_name,
         create_mode=create_mode,
@@ -3355,7 +3385,8 @@ def cli_cosmosdb_table_restore(cmd,
                                resource_group_name,
                                account_name,
                                table_name,
-                               restore_timestamp=None):
+                               restore_timestamp=None,
+                               disable_ttl=None):
 
     from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_database_accounts
     # """Restores the deleted Azure Cosmos DB Table"""
@@ -3418,6 +3449,9 @@ def cli_cosmosdb_table_restore(cmd,
         restore_source=restorable_database_account.id,
         restore_timestamp_in_utc=restore_timestamp
     )
+
+    if disable_ttl is not None:
+        restore_parameters.restore_with_ttl_disabled=disable_ttl
 
     table_resource = TableCreateUpdateParameters(
         resource=TableResource(id=table_name,

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
@@ -2906,7 +2906,7 @@ class CosmosDBTests(ScenarioTest):
         unique_key_policy = '"{\\"uniqueKeys\\": [{\\"paths\\": [\\"/path/to/key1\\"]}, {\\"paths\\": [\\"/path/to/key2\\"]}]}"'
         conflict_resolution_policy = '"{\\"mode\\": \\"lastWriterWins\\", \\"conflictResolutionPath\\": \\"/path\\"}"'
         indexing = '"{\\"indexingMode\\": \\"consistent\\", \\"automatic\\": true, \\"includedPaths\\": [{\\"path\\": \\"/*\\"}], \\"excludedPaths\\": [{\\"path\\": \\"/headquarters/employees/?\\"}]}"'
-        location = "australiaeast"
+        location = "WestUS"
         tp1 = 1000
         ttl = 1800
 

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
@@ -2605,16 +2605,18 @@ class CosmosDBTests(ScenarioTest):
         time.sleep(240)
         restore_ts_string = restore_ts.isoformat()
         self.kwargs.update({
-            'rts': restore_ts_string
+            'rts': restore_ts_string,
+            'dt': True
         })
 
-        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc}')
+        self.cmd('az cosmosdb restore -n {restored_acc} -g {rg} -a {acc} --restore-timestamp {rts} --location {loc} --disable-ttl {dt}')
         restored_account = self.cmd('az cosmosdb show -n {restored_acc} -g {rg}', checks=[
             self.check('restoreParameters.restoreMode', 'PointInTime')
         ]).get_output_in_json()
 
         assert restored_account['restoreParameters']['restoreSource'] == restorable_database_account['id']
         assert restored_account['restoreParameters']['restoreTimestampInUtc'] == restore_ts_string
+        assert restored_account['restoreParameters']['restoreWithTtlDisabled'] == True
 
     @ResourceGroupPreparer(name_prefix='cli_test_cosmosdb_table_restorable_commands', location='eastus2')
     @AllowLargeResponse(size_kb=9999)
@@ -2904,8 +2906,9 @@ class CosmosDBTests(ScenarioTest):
         unique_key_policy = '"{\\"uniqueKeys\\": [{\\"paths\\": [\\"/path/to/key1\\"]}, {\\"paths\\": [\\"/path/to/key2\\"]}]}"'
         conflict_resolution_policy = '"{\\"mode\\": \\"lastWriterWins\\", \\"conflictResolutionPath\\": \\"/path\\"}"'
         indexing = '"{\\"indexingMode\\": \\"consistent\\", \\"automatic\\": true, \\"includedPaths\\": [{\\"path\\": \\"/*\\"}], \\"excludedPaths\\": [{\\"path\\": \\"/headquarters/employees/?\\"}]}"'
-        location = "WestUS"
+        location = "australiaeast"
         tp1 = 1000
+        ttl = 1800
 
         self.kwargs.update({
             'acc': self.create_random_name(prefix='cli', length=15),
@@ -2916,7 +2919,8 @@ class CosmosDBTests(ScenarioTest):
             "conflict_resolution": conflict_resolution_policy,
             "indexing": indexing,
             'loc': location,
-            'tp1': tp1
+            'tp1': tp1,
+            'ttl': ttl
         })
 
         self.cmd('az cosmosdb create -n {acc} -g {rg} --backup-policy-type Continuous --locations regionName={loc}')
@@ -2924,10 +2928,11 @@ class CosmosDBTests(ScenarioTest):
 
         assert not self.cmd('az cosmosdb sql container exists -g {rg} -a {acc} -d {db_name} -n {ctn_name}').get_output_in_json()
 
-        container_create = self.cmd('az cosmosdb sql container create -g {rg} -a {acc} -d {db_name} -n {ctn_name} -p {part} --unique-key-policy {unique_key} --conflict-resolution-policy {conflict_resolution} --idx {indexing}').get_output_in_json()
+        container_create = self.cmd('az cosmosdb sql container create -g {rg} -a {acc} -d {db_name} -n {ctn_name} -p {part} --unique-key-policy {unique_key} --conflict-resolution-policy {conflict_resolution} --idx {indexing} --ttl {ttl}').get_output_in_json()
 
         assert container_create["name"] == ctn_name
         assert container_create["resource"]["partitionKey"]["paths"][0] == partition_key
+        assert container_create["resource"]["defaultTtl"] == ttl
         assert len(container_create["resource"]["uniqueKeyPolicy"]["uniqueKeys"]) == 2
         assert container_create["resource"]["conflictResolutionPolicy"]["mode"] == "lastWriterWins"
         assert container_create["resource"]["indexingPolicy"]["excludedPaths"][0]["path"] == "/headquarters/employees/?"
@@ -2941,7 +2946,8 @@ class CosmosDBTests(ScenarioTest):
         restore_ts_string = datetime.utcnow().isoformat()
 
         self.kwargs.update({
-            'rts': restore_ts_string
+            'rts': restore_ts_string,
+            'dt': True
         })
         import time
         time.sleep(300)
@@ -2983,7 +2989,7 @@ class CosmosDBTests(ScenarioTest):
         import time
         time.sleep(500)
 
-        self.cmd('az cosmosdb sql database restore -g {rg} -a {acc} -n {db_name} --restore-timestamp {rts}')
+        self.cmd('az cosmosdb sql database restore -g {rg} -a {acc} -n {db_name} --restore-timestamp {rts} --disable-ttl {dt}')
 
         database_restore = self.cmd('az cosmosdb sql database show -g {rg} -a {acc} -n {db_name}').get_output_in_json()
         assert database_restore["name"] == db_name
@@ -2993,6 +2999,7 @@ class CosmosDBTests(ScenarioTest):
 
         container_show = self.cmd('az cosmosdb sql container show -g {rg} -a {acc} -d {db_name} -n {ctn_name}').get_output_in_json()
         assert container_show["name"] == ctn_name
+        assert container_show["resource"]["defaultTtl"] == None
 
         self.cmd('az cosmosdb sql database delete -g {rg} -a {acc} -n {db_name} --yes')
         database_list = self.cmd('az cosmosdb sql database list -g {rg} -a {acc}').get_output_in_json()


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az cosmosdb restore`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Releasing a new feature in az cosmosdb restore command: Restore with TTL Disabled.
Already released in preview, and this PR is for GAing

**Testing Guide**
<!--Example commands with explanations.-->

`cli_test_cosmosdb_table_account_restore_command`
`cli_test_cosmosdb_sql_shared_database_restore`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature
[CosmosDB Restore] az cosmosdb restore: Add support for Restore with Time-To-Live Disabled. '--disable-ttl' parameter can be used during restore.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
